### PR TITLE
Re-export gaps, add DRM timing, don't show Identical AA Muts

### DIFF
--- a/src/export_to_auspice.py
+++ b/src/export_to_auspice.py
@@ -44,17 +44,7 @@ def tree_to_json(node, extra_attr = []):
 
 def attach_tree_meta_data(T, node_meta):
     def parse_mutations(muts):
-        allMut = muts.split(',') if type(muts) in [str, unicode] else ""
-        realMut=[]
-        #This exclude gaps from displaying in Auspice. They're ignored, in
-        #treebuilding anyway, and clutter up display/prevent from seeing real ones
-        for m in allMut:
-            if '-' not in m:
-                realMut.append(m)
-        if len(realMut)==0:
-            realMut = [""]
-        return realMut
-        #return muts.split(',') if type(muts) in [str, unicode] else ""
+        return muts.split(',') if type(muts) in [str, unicode] else ""
 
     for n in T.find_clades(order='preorder'):
         n.attr={}

--- a/src/find_drm.py
+++ b/src/find_drm.py
@@ -156,6 +156,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     path = args.path
 
+    import time
+    start = time.time()
+
     compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path), compressed=False)
 
     sequences = compress_seq['sequences']
@@ -184,4 +187,5 @@ if __name__ == '__main__':
     with open(drm_color_maps(path), 'w') as the_file:
         the_file.write("\n".join(newColAdds))
 
-
+    end = time.time()
+    print "DRM processing took {}".format(str(end-start))

--- a/src/translate.py
+++ b/src/translate.py
@@ -192,6 +192,7 @@ def get_amino_acid_mutations(tree, fname):
 def assign_amino_acid_muts_vcf(prots, path):
     tree_meta = read_tree_meta_data(path)
     seqNames = prots[prots.keys()[0]]['sequences'].keys()
+    excluded = []
 
     #go through every gene in the prots nested dict
     for fname, prot in prots.iteritems():
@@ -210,18 +211,29 @@ def assign_amino_acid_muts_vcf(prots, path):
 
             pattern = [ refb+str(pos)+sequences[k][pi] if pi in sequences[k].keys()
                         else "" for k,v in sequences.iteritems() ]
-            pats.append(pattern)
+
+            #if the exact same mutation in all sequences, don't include! (only mutant against ref..)
+            if not (len(pattern)==len(sequences) and len(np.unique(pattern))==1):
+                pats.append(pattern)
             i+=1
 
         #convert our list of lists to matrix
         patMat = np.matrix(pats)
 
-        #for every sequence, assign the mutations in tree_meta
-        for i in xrange(len(seqNames)):
-            node_name = seqNames[i]
-            ary = np.array(patMat[:,i]).reshape(-1,)
-            tree_meta[node_name][fname+'_mutations'] = ",".join(ary[ary != ''])
+        #don't include if all the mutations identical across sequences! (only mutant against ref..)
+        if len(pats) != 0:
+            #for every sequence, assign the mutations in tree_meta
+            for i in xrange(len(seqNames)):
+                node_name = seqNames[i]
+                ary = np.array(patMat[:,i]).reshape(-1,)
+                tree_meta[node_name][fname+'_mutations'] = ",".join(ary[ary != ''])
+        else:
+            excluded.append(fname)
 
+    if len(excluded) != 0:
+        print "{} genes do not differ across the tree. They will not be added to tree meta-data or shown in auspice".format(len(excluded))
+        
+            
     #write it out!
     write_tree_meta_data(path, tree_meta)
 


### PR DESCRIPTION
`export_to_auspice.py/attach_tree_meta_data` reverted to original code with exports all mutations, instead of excluding gaps. As `auspice` now modified to separate out 'N' and '-' mutations in display, all can be exported.

`find_drm.py` modified to add a timer (to bring in line with other scripts)

`translate.py/assign_amino_acid_muts_vcf` only writes AA mutations to the tree (which will be displayed in `auspice`) if they are not identical across the tree (this happens when the mutant against the reference, but not across the tree). This prevents the same AA mutation showing for every sequence.
However, these mutations **are** still written out in the psuedo-VCF file for AA mutations, as this continues to show the gene/site as mutant against the reference.
