### PR TITLE
VCF Input/Output Update

### DIFF
--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,7 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
-    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
+    return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -96,12 +96,16 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     if ref != None: #if VCF, fix pi
         pi = np.array([0.1618, 0.3188, 0.3176, 0.1618, 0.04]) #from real runs (Walker 2018)
 
+    #for lee 2015
+    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, #relaxed_clock={"slack":1e-8, "coupling":1e-8}, #fixed_clock_rate=1.3e-7,
+     #  resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
-           resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
+        resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
-
-
+    #for walker 2018
+    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, relaxed_clock={"slack":1e-6, "coupling":1e-6}, fixed_clock_rate=3.5e-7, #relaxed_clock={"slack":None, "coupling":None}, #fixed_clock_rate=0.000001,
+    #   resolve_polytomies=False, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
 
     for n in T.find_clades():

--- a/src/build_tree.py
+++ b/src/build_tree.py
@@ -39,7 +39,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
 
 
 def build_iqtree(aln_file, out_file, iqmodel, clean_up=True, nthreads=2):
-    return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
+    #return Phylo.read(out_file.replace(".nwk",".iqtree.nwk"), 'newick') #uncomment for debug skip straight to TreeTime
     if iqmodel:
         call = ["iqtree", "-nt", str(nthreads), "-s", aln_file, "-m", iqmodel[0],
             ">", "iqtree.log"]
@@ -96,16 +96,12 @@ def timetree(tree=None, aln=None, ref=None, seq_meta=None, keeproot=False,
     if ref != None: #if VCF, fix pi
         pi = np.array([0.1618, 0.3188, 0.3176, 0.1618, 0.04]) #from real runs (Walker 2018)
 
-    #for lee 2015
-    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, #relaxed_clock={"slack":1e-8, "coupling":1e-8}, #fixed_clock_rate=1.3e-7,
-     #  resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
         resolve_polytomies=resolve_polytomies, max_iter=max_iter, fixed_pi=pi, **kwarks)
 
-    #for walker 2018
-    #tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal, relaxed_clock={"slack":1e-6, "coupling":1e-6}, fixed_clock_rate=3.5e-7, #relaxed_clock={"slack":None, "coupling":None}, #fixed_clock_rate=0.000001,
-    #   resolve_polytomies=False, max_iter=max_iter, fixed_pi=pi, **kwarks)
+
+
 
 
     for n in T.find_clades():
@@ -143,7 +139,8 @@ def export_sequence_fasta(T, path):
 
 def export_sequence_VCF(tt, path, var_ambigs=False):
     tree_dict = tt.get_tree_dict(var_ambigs)
-    write_VCF_style_alignment(tree_dict, tree_vcf_alignment(path,'nuc'))
+    #in new augur, set 'compress' based on input file ending!
+    write_VCF_style_alignment(tree_dict, tree_vcf_alignment(path,'nuc'), compress=False)
 
 
 def write_out_variable_fasta(compress_seq, path, drmfile=None):

--- a/src/find_drm.py
+++ b/src/find_drm.py
@@ -159,7 +159,7 @@ if __name__ == '__main__':
     import time
     start = time.time()
 
-    compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path), compressed=False)
+    compress_seq = read_in_vcf(tree_vcf_alignment(path), ref_fasta(path))
 
     sequences = compress_seq['sequences']
     positions = compress_seq['positions']

--- a/src/translate.py
+++ b/src/translate.py
@@ -114,7 +114,7 @@ def translate_vcf(vcf_fname, reference, path, feature_names=None):
     import time
     start = time.time()
     try:
-        vcf_dict = read_in_vcf(vcf_fname, ref_fasta(path), compressed=False )
+        vcf_dict = read_in_vcf(vcf_fname, ref_fasta(path))
     except:
         print "Loading input alignment failed!: {}".format(vcf_fname)
     end = time.time()
@@ -153,7 +153,8 @@ def translate_vcf(vcf_fname, reference, path, feature_names=None):
 
     start = time.time()
     #print out VCF of proteins
-    write_VCF_translation(prots, translation_vcf_file(path), translation_ref_file(path))
+    #in new augur, set compress depending on input file ending!
+    write_VCF_translation(prots, translation_vcf_file(path), translation_ref_file(path), compress=False)
     end = time.time()
     print "Writing out VCF took {}".format(str(end-start))
 
@@ -232,8 +233,8 @@ def assign_amino_acid_muts_vcf(prots, path):
 
     if len(excluded) != 0:
         print "{} genes do not differ across the tree. They will not be added to tree meta-data or shown in auspice".format(len(excluded))
-        
-            
+
+
     #write it out!
     write_tree_meta_data(path, tree_meta)
 

--- a/src/util.py
+++ b/src/util.py
@@ -88,7 +88,7 @@ def collect_tree_meta_data(T, fields, isvcf=False, meta=None):
 
     return meta
 
-def read_in_vcf(vcf_file, ref_file, compressed=True):
+def read_in_vcf(vcf_file, ref_file):
     """
     Reads in a vcf.gz file (or vcf if compressed is False) and associated
     reference sequence fasta (to which the VCF file is mapped)
@@ -169,7 +169,8 @@ def read_in_vcf(vcf_file, ref_file, compressed=True):
     altLoc = 0
     sampLoc = 9
 
-    if compressed: #must use 2 diff functions depending on compressed or not
+    #Use different openers depending on whether compressed
+    if vcf_file.endswith(('.gz', '.GZ')):
         opn = gzip.open
     else:
         opn = open
@@ -561,7 +562,7 @@ def write_json(data, file_name, indent=1):
         json.dump(data, handle, indent=indent)
         handle.close()
 
-def write_VCF_style_alignment(tree_dict, file_name):
+def write_VCF_style_alignment(tree_dict, file_name, compress=False):
     """
     Writes out a VCF-style file (which seems to be minimally handleable
     by vcftools and pyvcf) of the alignment from the input of a dict
@@ -754,6 +755,12 @@ def write_VCF_style_alignment(tree_dict, file_name):
     with open(file_name, 'a') as the_file:
         the_file.write("\n".join(vcfWrite))
 
+    if compress:
+        import os
+        call = ["gzip", file_name]
+        os.system(" ".join(call))
+
+
 
 ########################################
 # translation
@@ -914,7 +921,7 @@ def load_features(reference, feature_names=None):
     return features
 
 
-def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
+def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name, compress=False):
     """
     Writes out a VCF-style file (which seems to be minimally handleable
     by vcftools and pyvcf) of the AA differences between sequences and the reference.
@@ -990,6 +997,10 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
     with open(vcf_file_name, 'a') as the_file:
         the_file.write("\n".join(vcfWrite))
 
+    if compress:
+        import os
+        call = ["gzip", vcf_file_name]
+        os.system(" ".join(call))
 
 def load_lat_long_defs():
     places = {}


### PR DESCRIPTION
Functionality now included that checks file name to determine whether files are .vcf or .vcf.gz and handles/opens appropriately, and to allow .vcf.gz output if input is .vcf.gz

Though manually tested with both types of files all through the pipeline, this is not fully implemented in `augurlinos` because of the fixed-file-name setup. Comments have been added where not yet fully implemented to explain what should be changed when moving to new `augur`.